### PR TITLE
Update package.json to use the latest version of easygraphql-load-tester

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "artillery": "^1.6.0-27",
-    "easygraphql-load-tester": "^0.3.5",
+    "easygraphql-load-tester": "^0.3.8",
     "fs-extra": "^7.0.1",
     "inquirer": "^6.2.2",
     "minimist": "^1.2.0",


### PR DESCRIPTION
For `easygraphql-load-tester` use 0.3.8 version instead of 0.3.5 